### PR TITLE
feat: convert YJN279 text to profile page link

### DIFF
--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -149,7 +149,7 @@ export default function Portfolio() {
           <h1 className="text-5xl md:text-6xl font-bold text-gray-900 mb-6">
             Welcome aboard
             <br />
-            <span className="text-blue-600">Flight <span className="underline">YJN279</span></span>
+            <span className="text-blue-600">Flight <Link to="/profile" className="underline hover:text-blue-700 transition-colors">YJN279</Link></span>
           </h1>
           <p className="text-xl text-gray-600 mb-8 max-w-2xl mx-auto">
            Hello world. Welcome on board flight YJN279. The captain in command of this website is NAKAMURA Yuji and my co-pilot is <span className="line-through">GitHub</span> Cursor. We are now ready for departure. Please let me know if you need any assistance, and I hope that you enjoy the flight with me 😉


### PR DESCRIPTION
Converts the underlined YJN279 text in the homepage heading to a clickable link that navigates to the profile page.

## Changes
- Updated app/routes/home.tsx line 152
- Changed span element to Link component pointing to /profile
- Added hover effect for better UX
- Maintains original underline styling

Resolves #3

Generated with [Claude Code](https://claude.ai/code)