### PR TITLE
feat: 記事一覧機能のAPI取得実装

### DIFF
--- a/app/components/sections/ArticlesList.tsx
+++ b/app/components/sections/ArticlesList.tsx
@@ -1,0 +1,243 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { useArticles } from "@/hooks/useArticles";
+import type { Article } from "@/types";
+import {
+  AlertCircle,
+  Calendar,
+  Clock,
+  ExternalLink,
+  Eye,
+  Heart,
+  Loader2,
+  RefreshCw,
+} from "lucide-react";
+
+interface ArticlesListProps {
+  platform?: 'zenn' | 'qiita' | 'note';
+  showLoadMore?: boolean;
+  showRefresh?: boolean;
+}
+
+export function ArticlesList({ 
+  platform, 
+  showLoadMore = true,
+  showRefresh = true 
+}: ArticlesListProps) {
+  const { articles, loading, error, hasMore, fetchMore, refresh } = useArticles(platform);
+
+  const getPlatformColor = (platform: string) => {
+    switch (platform) {
+      case "Zenn":
+        return "bg-blue-100 text-blue-800";
+      case "Qiita":
+        return "bg-green-100 text-green-800";
+      case "Note":
+        return "bg-purple-100 text-purple-800";
+      default:
+        return "bg-gray-100 text-gray-800";
+    }
+  };
+
+  const handleLoadMore = async () => {
+    await fetchMore();
+  };
+
+  const handleRefresh = async () => {
+    await refresh();
+  };
+
+  if (loading && articles.length === 0) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="flex items-center gap-2 text-gray-600">
+          <Loader2 className="h-5 w-5 animate-spin" />
+          <span>記事を読み込み中...</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (error && articles.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-center">
+        <AlertCircle className="h-12 w-12 text-red-500 mb-4" />
+        <h3 className="text-lg font-semibold text-gray-900 mb-2">
+          記事の取得に失敗しました
+        </h3>
+        <p className="text-gray-600 mb-4 max-w-md">
+          {error}
+        </p>
+        {showRefresh && (
+          <Button onClick={handleRefresh} variant="outline">
+            <RefreshCw className="h-4 w-4 mr-2" />
+            再試行
+          </Button>
+        )}
+      </div>
+    );
+  }
+
+  if (articles.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-center">
+        <div className="text-gray-400 mb-4">
+          <ExternalLink className="h-12 w-12" />
+        </div>
+        <h3 className="text-lg font-semibold text-gray-900 mb-2">
+          記事が見つかりませんでした
+        </h3>
+        <p className="text-gray-600">
+          {platform ? `${platform}に記事がないか、APIエラーが発生しています。` : "記事がないか、APIエラーが発生しています。"}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Control buttons */}
+      {showRefresh && (
+        <div className="flex justify-end">
+          <Button 
+            onClick={handleRefresh} 
+            variant="outline" 
+            size="sm"
+            disabled={loading}
+          >
+            <RefreshCw className={`h-4 w-4 mr-2 ${loading ? 'animate-spin' : ''}`} />
+            更新
+          </Button>
+        </div>
+      )}
+
+      {/* Articles grid */}
+      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        {articles.map((article) => (
+          <Card
+            key={article.id}
+            className="hover:shadow-xl transition-all duration-300 border-2 border-blue-100"
+          >
+            <CardHeader>
+              <div className="flex items-start justify-between mb-2">
+                <Badge
+                  variant="secondary"
+                  className={getPlatformColor(article.platform || "")}
+                >
+                  {article.platform}
+                </Badge>
+                <a
+                  href={article.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="p-1 hover:bg-gray-100 rounded"
+                >
+                  <ExternalLink className="h-4 w-4" />
+                </a>
+              </div>
+              <CardTitle className="text-xl">
+                <a
+                  href={article.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="hover:text-blue-600 transition-colors"
+                >
+                  {article.title}
+                </a>
+              </CardTitle>
+              <CardDescription className="text-base">
+                {article.description}
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-4">
+                {article.excerpt && (
+                  <p className="text-sm text-gray-600 italic">
+                    "{article.excerpt}"
+                  </p>
+                )}
+                <div className="flex flex-wrap gap-1">
+                  {article.tags.slice(0, 3).map((tag) => (
+                    <Badge key={tag} variant="outline" className="text-xs">
+                      {tag}
+                    </Badge>
+                  ))}
+                  {article.tags.length > 3 && (
+                    <Badge variant="outline" className="text-xs">
+                      +{article.tags.length - 3}
+                    </Badge>
+                  )}
+                </div>
+                <div className="flex items-center justify-between text-sm text-gray-600">
+                  <div className="flex items-center gap-4">
+                    <div className="flex items-center gap-1">
+                      <Calendar className="h-4 w-4" />
+                      <span>{article.publishedAt}</span>
+                    </div>
+                    {article.readTime && (
+                      <div className="flex items-center gap-1">
+                        <Clock className="h-4 w-4" />
+                        <span>{article.readTime}</span>
+                      </div>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-3">
+                    {article.views && (
+                      <div className="flex items-center gap-1">
+                        <Eye className="h-4 w-4" />
+                        <span>{article.views}</span>
+                      </div>
+                    )}
+                    {article.likes && (
+                      <div className="flex items-center gap-1">
+                        <Heart className="h-4 w-4" />
+                        <span>{article.likes}</span>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* Load more button */}
+      {showLoadMore && hasMore && (
+        <div className="flex justify-center pt-6">
+          <Button 
+            onClick={handleLoadMore} 
+            variant="outline"
+            disabled={loading}
+          >
+            {loading ? (
+              <>
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                読み込み中...
+              </>
+            ) : (
+              "さらに読み込む"
+            )}
+          </Button>
+        </div>
+      )}
+
+      {/* Error message for additional loads */}
+      {error && articles.length > 0 && (
+        <div className="flex items-center justify-center py-4">
+          <div className="flex items-center gap-2 text-red-600 bg-red-50 px-4 py-2 rounded-lg">
+            <AlertCircle className="h-4 w-4" />
+            <span className="text-sm">{error}</span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/sections/ArticlesList.tsx
+++ b/app/components/sections/ArticlesList.tsx
@@ -21,17 +21,18 @@ import {
 } from "lucide-react";
 
 interface ArticlesListProps {
-  platform?: 'zenn' | 'qiita' | 'note';
+  platform?: "zenn" | "qiita" | "note";
   showLoadMore?: boolean;
   showRefresh?: boolean;
 }
 
-export function ArticlesList({ 
-  platform, 
+export function ArticlesList({
+  platform,
   showLoadMore = true,
-  showRefresh = true 
+  showRefresh = true,
 }: ArticlesListProps) {
-  const { articles, loading, error, hasMore, fetchMore, refresh } = useArticles(platform);
+  const { articles, loading, error, hasMore, fetchMore, refresh } =
+    useArticles(platform);
 
   const getPlatformColor = (platform: string) => {
     switch (platform) {
@@ -72,9 +73,7 @@ export function ArticlesList({
         <h3 className="text-lg font-semibold text-gray-900 mb-2">
           記事の取得に失敗しました
         </h3>
-        <p className="text-gray-600 mb-4 max-w-md">
-          {error}
-        </p>
+        <p className="text-gray-600 mb-4 max-w-md">{error}</p>
         {showRefresh && (
           <Button onClick={handleRefresh} variant="outline">
             <RefreshCw className="h-4 w-4 mr-2" />
@@ -95,7 +94,9 @@ export function ArticlesList({
           記事が見つかりませんでした
         </h3>
         <p className="text-gray-600">
-          {platform ? `${platform}に記事がないか、APIエラーが発生しています。` : "記事がないか、APIエラーが発生しています。"}
+          {platform
+            ? `${platform}に記事がないか、APIエラーが発生しています。`
+            : "記事がないか、APIエラーが発生しています。"}
         </p>
       </div>
     );
@@ -106,13 +107,15 @@ export function ArticlesList({
       {/* Control buttons */}
       {showRefresh && (
         <div className="flex justify-end">
-          <Button 
-            onClick={handleRefresh} 
-            variant="outline" 
+          <Button
+            onClick={handleRefresh}
+            variant="outline"
             size="sm"
             disabled={loading}
           >
-            <RefreshCw className={`h-4 w-4 mr-2 ${loading ? 'animate-spin' : ''}`} />
+            <RefreshCw
+              className={`h-4 w-4 mr-2 ${loading ? "animate-spin" : ""}`}
+            />
             更新
           </Button>
         </div>
@@ -212,11 +215,7 @@ export function ArticlesList({
       {/* Load more button */}
       {showLoadMore && hasMore && (
         <div className="flex justify-center pt-6">
-          <Button 
-            onClick={handleLoadMore} 
-            variant="outline"
-            disabled={loading}
-          >
+          <Button onClick={handleLoadMore} variant="outline" disabled={loading}>
             {loading ? (
               <>
                 <Loader2 className="h-4 w-4 mr-2 animate-spin" />

--- a/app/hooks/useArticles.ts
+++ b/app/hooks/useArticles.ts
@@ -1,7 +1,7 @@
-import { useState, useEffect } from "react";
+import { articleApiClient } from "@/lib/api-clients";
 import type { Article } from "@/types";
 import type { ApiResponse } from "@/types/api";
-import { articleApiClient } from "@/lib/api-clients";
+import { useCallback, useEffect, useState } from "react";
 
 interface UseArticlesState {
   articles: Article[];
@@ -15,58 +15,66 @@ interface UseArticlesResult extends UseArticlesState {
   refresh: () => Promise<void>;
 }
 
-export function useArticles(platform?: 'zenn' | 'qiita' | 'note'): UseArticlesResult {
+export function useArticles(
+  platform?: "zenn" | "qiita" | "note",
+): UseArticlesResult {
   const [state, setState] = useState<UseArticlesState>({
     articles: [],
     loading: true,
     error: null,
-    hasMore: false
+    hasMore: false,
   });
 
   const [currentPage, setCurrentPage] = useState(1);
 
-  const fetchArticles = async (page = 1, append = false) => {
-    try {
-      setState(prev => ({ ...prev, loading: true, error: null }));
+  const fetchArticles = useCallback(
+    async (page = 1, append = false) => {
+      try {
+        setState((prev) => ({ ...prev, loading: true, error: null }));
 
-      let response: ApiResponse<Article>;
+        let response: ApiResponse<Article>;
 
-      if (platform === 'qiita') {
-        response = await articleApiClient.fetchQiitaArticles(page);
-      } else if (platform === 'zenn') {
-        response = await articleApiClient.fetchZennArticles(page, 20, true); // Use RSS
-      } else if (platform === 'note') {
-        response = await articleApiClient.fetchNoteArticles(page, 20, true); // Use RSS
-      } else {
-        // Fetch all platforms - for now just use Qiita as it's the only working one
-        response = await articleApiClient.fetchQiitaArticles(page);
-      }
+        if (platform === "qiita") {
+          response = await articleApiClient.fetchQiitaArticles(page);
+        } else if (platform === "zenn") {
+          response = await articleApiClient.fetchZennArticles(page, 20, true); // Use RSS
+        } else if (platform === "note") {
+          response = await articleApiClient.fetchNoteArticles(page, 20, true); // Use RSS
+        } else {
+          // Fetch all platforms - for now just use Qiita as it's the only working one
+          response = await articleApiClient.fetchQiitaArticles(page);
+        }
 
-      if (response.error) {
-        setState(prev => ({
+        if (response.error) {
+          setState((prev) => ({
+            ...prev,
+            loading: false,
+            error: response.error?.message || "Unknown error occurred",
+          }));
+          return;
+        }
+
+        setState((prev) => ({
+          ...prev,
+          articles: append
+            ? [...prev.articles, ...response.data]
+            : response.data,
+          loading: false,
+          hasMore: response.hasMore || false,
+        }));
+
+        setCurrentPage(page);
+      } catch (error) {
+        setState((prev) => ({
           ...prev,
           loading: false,
-          error: response.error!.message
+          error:
+            error instanceof Error ? error.message : "記事の取得に失敗しました",
         }));
-        return;
       }
-
-      setState(prev => ({
-        ...prev,
-        articles: append ? [...prev.articles, ...response.data] : response.data,
-        loading: false,
-        hasMore: response.hasMore || false
-      }));
-
-      setCurrentPage(page);
-    } catch (error) {
-      setState(prev => ({
-        ...prev,
-        loading: false,
-        error: error instanceof Error ? error.message : "記事の取得に失敗しました"
-      }));
-    }
-  };
+    },
+    [platform],
+  );
 
   const fetchMore = async () => {
     if (state.hasMore && !state.loading) {
@@ -81,12 +89,12 @@ export function useArticles(platform?: 'zenn' | 'qiita' | 'note'): UseArticlesRe
 
   useEffect(() => {
     fetchArticles(1, false);
-  }, [platform]);
+  }, [fetchArticles]);
 
   return {
     ...state,
     fetchMore,
-    refresh
+    refresh,
   };
 }
 
@@ -103,13 +111,13 @@ export function useAllPlatformArticles() {
     qiita: [],
     note: [],
     loading: true,
-    errors: {}
+    errors: {},
   });
 
-  const fetchAllArticles = async () => {
+  const fetchAllArticles = useCallback(async () => {
     try {
-      setState(prev => ({ ...prev, loading: true }));
-      
+      setState((prev) => ({ ...prev, loading: true }));
+
       const results = await articleApiClient.fetchAllArticles();
       const errors: { [key: string]: string } = {};
 
@@ -128,25 +136,26 @@ export function useAllPlatformArticles() {
         qiita: results.qiita.data,
         note: results.note.data,
         loading: false,
-        errors
+        errors,
       });
     } catch (error) {
-      setState(prev => ({
+      setState((prev) => ({
         ...prev,
         loading: false,
         errors: {
-          general: error instanceof Error ? error.message : "記事の取得に失敗しました"
-        }
+          general:
+            error instanceof Error ? error.message : "記事の取得に失敗しました",
+        },
       }));
     }
-  };
+  }, []);
 
   useEffect(() => {
     fetchAllArticles();
-  }, []);
+  }, [fetchAllArticles]);
 
   return {
     ...state,
-    refresh: fetchAllArticles
+    refresh: fetchAllArticles,
   };
 }

--- a/app/hooks/useArticles.ts
+++ b/app/hooks/useArticles.ts
@@ -1,0 +1,152 @@
+import { useState, useEffect } from "react";
+import type { Article } from "@/types";
+import type { ApiResponse } from "@/types/api";
+import { articleApiClient } from "@/lib/api-clients";
+
+interface UseArticlesState {
+  articles: Article[];
+  loading: boolean;
+  error: string | null;
+  hasMore: boolean;
+}
+
+interface UseArticlesResult extends UseArticlesState {
+  fetchMore: () => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+export function useArticles(platform?: 'zenn' | 'qiita' | 'note'): UseArticlesResult {
+  const [state, setState] = useState<UseArticlesState>({
+    articles: [],
+    loading: true,
+    error: null,
+    hasMore: false
+  });
+
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const fetchArticles = async (page = 1, append = false) => {
+    try {
+      setState(prev => ({ ...prev, loading: true, error: null }));
+
+      let response: ApiResponse<Article>;
+
+      if (platform === 'qiita') {
+        response = await articleApiClient.fetchQiitaArticles(page);
+      } else if (platform === 'zenn') {
+        response = await articleApiClient.fetchZennArticles(page, 20, true); // Use RSS
+      } else if (platform === 'note') {
+        response = await articleApiClient.fetchNoteArticles(page, 20, true); // Use RSS
+      } else {
+        // Fetch all platforms - for now just use Qiita as it's the only working one
+        response = await articleApiClient.fetchQiitaArticles(page);
+      }
+
+      if (response.error) {
+        setState(prev => ({
+          ...prev,
+          loading: false,
+          error: response.error!.message
+        }));
+        return;
+      }
+
+      setState(prev => ({
+        ...prev,
+        articles: append ? [...prev.articles, ...response.data] : response.data,
+        loading: false,
+        hasMore: response.hasMore || false
+      }));
+
+      setCurrentPage(page);
+    } catch (error) {
+      setState(prev => ({
+        ...prev,
+        loading: false,
+        error: error instanceof Error ? error.message : "記事の取得に失敗しました"
+      }));
+    }
+  };
+
+  const fetchMore = async () => {
+    if (state.hasMore && !state.loading) {
+      await fetchArticles(currentPage + 1, true);
+    }
+  };
+
+  const refresh = async () => {
+    setCurrentPage(1);
+    await fetchArticles(1, false);
+  };
+
+  useEffect(() => {
+    fetchArticles(1, false);
+  }, [platform]);
+
+  return {
+    ...state,
+    fetchMore,
+    refresh
+  };
+}
+
+// Hook for fetching articles from all platforms
+export function useAllPlatformArticles() {
+  const [state, setState] = useState<{
+    zenn: Article[];
+    qiita: Article[];
+    note: Article[];
+    loading: boolean;
+    errors: { [key: string]: string };
+  }>({
+    zenn: [],
+    qiita: [],
+    note: [],
+    loading: true,
+    errors: {}
+  });
+
+  const fetchAllArticles = async () => {
+    try {
+      setState(prev => ({ ...prev, loading: true }));
+      
+      const results = await articleApiClient.fetchAllArticles();
+      const errors: { [key: string]: string } = {};
+
+      if (results.zenn.error) {
+        errors.zenn = results.zenn.error.message;
+      }
+      if (results.qiita.error) {
+        errors.qiita = results.qiita.error.message;
+      }
+      if (results.note.error) {
+        errors.note = results.note.error.message;
+      }
+
+      setState({
+        zenn: results.zenn.data,
+        qiita: results.qiita.data,
+        note: results.note.data,
+        loading: false,
+        errors
+      });
+    } catch (error) {
+      setState(prev => ({
+        ...prev,
+        loading: false,
+        errors: {
+          general: error instanceof Error ? error.message : "記事の取得に失敗しました"
+        }
+      }));
+    }
+  };
+
+  useEffect(() => {
+    fetchAllArticles();
+  }, []);
+
+  return {
+    ...state,
+    refresh: fetchAllArticles
+  };
+}

--- a/app/lib/api-clients.ts
+++ b/app/lib/api-clients.ts
@@ -1,10 +1,10 @@
 import type { Article } from "@/types";
-import type { 
-  ZennArticle, 
-  QiitaArticle, 
-  NoteArticle, 
-  ApiResponse, 
-  ApiError 
+import type {
+  ApiError,
+  ApiResponse,
+  NoteArticle,
+  QiitaArticle,
+  ZennArticle,
 } from "@/types/api";
 
 // Constants
@@ -15,8 +15,8 @@ const NOTE_API_BASE = "https://note.com/api/v2";
 // User IDs from the issue
 const USER_IDS = {
   zenn: "yuji0207",
-  qiita: "yjn279", 
-  note: "yjn279"
+  qiita: "yjn279",
+  note: "yjn279",
 } as const;
 
 // Helper function to estimate reading time
@@ -37,10 +37,10 @@ function formatCount(count: number): string {
 
 // Helper function to format date
 function formatDate(dateString: string): string {
-  return new Date(dateString).toLocaleDateString('ja-JP', {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit'
+  return new Date(dateString).toLocaleDateString("ja-JP", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
   });
 }
 
@@ -54,26 +54,28 @@ export class ZennApiClient {
       // Zenn doesn't have a public API, so we'll use RSS or scraping approach
       // For now, we'll return a simulated response indicating the limitation
       const error: ApiError = {
-        message: "Zenn does not provide a public API. Consider using RSS feed or web scraping.",
+        message:
+          "Zenn does not provide a public API. Consider using RSS feed or web scraping.",
         status: 501,
-        platform: 'zenn'
+        platform: "zenn",
       };
-      
+
       return {
         data: [],
         error,
-        hasMore: false
+        hasMore: false,
       };
     } catch (error) {
       const apiError: ApiError = {
-        message: error instanceof Error ? error.message : "Unknown error occurred",
+        message:
+          error instanceof Error ? error.message : "Unknown error occurred",
         status: 500,
-        platform: 'zenn'
+        platform: "zenn",
       };
-      
+
       return {
         data: [],
-        error: apiError
+        error: apiError,
       };
     }
   }
@@ -82,28 +84,29 @@ export class ZennApiClient {
   async fetchArticlesFromRSS(): Promise<ApiResponse<Article>> {
     try {
       const rssUrl = `https://zenn.dev/${this.username}/feed`;
-      
+
       // Note: This would need to be implemented with a CORS proxy or server-side
       const error: ApiError = {
-        message: "RSS parsing requires server-side implementation due to CORS restrictions",
+        message:
+          "RSS parsing requires server-side implementation due to CORS restrictions",
         status: 501,
-        platform: 'zenn'
+        platform: "zenn",
       };
-      
+
       return {
         data: [],
-        error
+        error,
       };
     } catch (error) {
       const apiError: ApiError = {
         message: error instanceof Error ? error.message : "RSS fetch failed",
         status: 500,
-        platform: 'zenn'
+        platform: "zenn",
       };
-      
+
       return {
         data: [],
-        error: apiError
+        error: apiError,
       };
     }
   }
@@ -117,10 +120,10 @@ export class QiitaApiClient {
   async fetchArticles(page = 1, perPage = 20): Promise<ApiResponse<Article>> {
     try {
       const url = `${this.baseUrl}/users/${this.username}/items?page=${page}&per_page=${perPage}`;
-      
+
       const response = await fetch(url, {
         headers: {
-          'Accept': 'application/json',
+          Accept: "application/json",
         },
       });
 
@@ -128,46 +131,47 @@ export class QiitaApiClient {
         const error: ApiError = {
           message: `Qiita API error: ${response.status} ${response.statusText}`,
           status: response.status,
-          platform: 'qiita'
+          platform: "qiita",
         };
-        
+
         return {
           data: [],
-          error
+          error,
         };
       }
 
       const qiitaArticles: QiitaArticle[] = await response.json();
-      
+
       const articles: Article[] = qiitaArticles.map((article) => ({
         id: `qiita-${article.id}`,
         title: article.title,
-        description: article.body.substring(0, 200) + "...",
-        excerpt: article.body.substring(0, 100) + "...",
-        tags: article.tags.map(tag => tag.name),
+        description: `${article.body.substring(0, 200)}...`,
+        excerpt: `${article.body.substring(0, 100)}...`,
+        tags: article.tags.map((tag) => tag.name),
         url: article.url,
         publishedAt: formatDate(article.created_at),
         readTime: estimateReadingTime(article.body),
         views: formatCount(article.page_views_count || 0),
         likes: formatCount(article.likes_count),
         platform: "Qiita",
-        featured: false
+        featured: false,
       }));
 
       return {
         data: articles,
-        hasMore: qiitaArticles.length === perPage
+        hasMore: qiitaArticles.length === perPage,
       };
     } catch (error) {
       const apiError: ApiError = {
-        message: error instanceof Error ? error.message : "Unknown error occurred",
+        message:
+          error instanceof Error ? error.message : "Unknown error occurred",
         status: 500,
-        platform: 'qiita'
+        platform: "qiita",
       };
-      
+
       return {
         data: [],
-        error: apiError
+        error: apiError,
       };
     }
   }
@@ -183,26 +187,28 @@ export class NoteApiClient {
       // Note's API is also not publicly available in the same way
       // We would need to use their RSS feed or implement server-side scraping
       const error: ApiError = {
-        message: "Note does not provide a public API. Consider using RSS feed or web scraping.",
+        message:
+          "Note does not provide a public API. Consider using RSS feed or web scraping.",
         status: 501,
-        platform: 'note'
+        platform: "note",
       };
-      
+
       return {
         data: [],
         error,
-        hasMore: false
+        hasMore: false,
       };
     } catch (error) {
       const apiError: ApiError = {
-        message: error instanceof Error ? error.message : "Unknown error occurred",
+        message:
+          error instanceof Error ? error.message : "Unknown error occurred",
         status: 500,
-        platform: 'note'
+        platform: "note",
       };
-      
+
       return {
         data: [],
-        error: apiError
+        error: apiError,
       };
     }
   }
@@ -211,28 +217,29 @@ export class NoteApiClient {
   async fetchArticlesFromRSS(): Promise<ApiResponse<Article>> {
     try {
       const rssUrl = `https://note.com/${this.username}/rss`;
-      
+
       // Note: This would need to be implemented with a CORS proxy or server-side
       const error: ApiError = {
-        message: "RSS parsing requires server-side implementation due to CORS restrictions",
+        message:
+          "RSS parsing requires server-side implementation due to CORS restrictions",
         status: 501,
-        platform: 'note'
+        platform: "note",
       };
-      
+
       return {
         data: [],
-        error
+        error,
       };
     } catch (error) {
       const apiError: ApiError = {
         message: error instanceof Error ? error.message : "RSS fetch failed",
         status: 500,
-        platform: 'note'
+        platform: "note",
       };
-      
+
       return {
         data: [],
-        error: apiError
+        error: apiError,
       };
     }
   }
@@ -246,29 +253,41 @@ export class ArticleApiClient {
 
   // Check if we're running in browser
   private get isBrowser(): boolean {
-    return typeof window !== 'undefined';
+    return typeof window !== "undefined";
   }
 
   // Use API route when in browser, direct API when server-side
-  private async fetchFromApiRoute(platform?: string, page = 1, useRss = false): Promise<any> {
+  private async fetchFromApiRoute(
+    platform?: string,
+    page = 1,
+    useRss = false,
+  ): Promise<
+    | ApiResponse<Article>
+    | {
+        zenn: ApiResponse<Article>;
+        qiita: ApiResponse<Article>;
+        note: ApiResponse<Article>;
+      }
+  > {
     if (!this.isBrowser) {
       // Server-side: use direct API calls
-      if (platform === 'qiita') {
+      if (platform === "qiita") {
         return this.qiitaClient.fetchArticles(page);
-      } else if (platform === 'zenn') {
-        return this.zennClient.fetchArticles(page);
-      } else if (platform === 'note') {
-        return this.noteClient.fetchArticles(page);
-      } else {
-        return this.fetchAllArticlesDirect();
       }
+      if (platform === "zenn") {
+        return this.zennClient.fetchArticles(page);
+      }
+      if (platform === "note") {
+        return this.noteClient.fetchArticles(page);
+      }
+      return this.fetchAllArticlesDirect();
     }
 
     // Browser: use API route
     const params = new URLSearchParams();
-    if (platform) params.set('platform', platform);
-    params.set('page', page.toString());
-    if (useRss) params.set('rss', 'true');
+    if (platform) params.set("platform", platform);
+    params.set("page", page.toString());
+    if (useRss) params.set("rss", "true");
 
     const response = await fetch(`/api/articles?${params}`);
     return response.json();
@@ -282,22 +301,43 @@ export class ArticleApiClient {
     const [zennResult, qiitaResult, noteResult] = await Promise.allSettled([
       this.zennClient.fetchArticles(),
       this.qiitaClient.fetchArticles(),
-      this.noteClient.fetchArticles()
+      this.noteClient.fetchArticles(),
     ]);
 
     return {
-      zenn: zennResult.status === 'fulfilled' ? zennResult.value : { 
-        data: [], 
-        error: { message: 'Failed to fetch Zenn articles', status: 500, platform: 'zenn' }
-      },
-      qiita: qiitaResult.status === 'fulfilled' ? qiitaResult.value : { 
-        data: [], 
-        error: { message: 'Failed to fetch Qiita articles', status: 500, platform: 'qiita' }
-      },
-      note: noteResult.status === 'fulfilled' ? noteResult.value : { 
-        data: [], 
-        error: { message: 'Failed to fetch Note articles', status: 500, platform: 'note' }
-      }
+      zenn:
+        zennResult.status === "fulfilled"
+          ? zennResult.value
+          : {
+              data: [],
+              error: {
+                message: "Failed to fetch Zenn articles",
+                status: 500,
+                platform: "zenn",
+              },
+            },
+      qiita:
+        qiitaResult.status === "fulfilled"
+          ? qiitaResult.value
+          : {
+              data: [],
+              error: {
+                message: "Failed to fetch Qiita articles",
+                status: 500,
+                platform: "qiita",
+              },
+            },
+      note:
+        noteResult.status === "fulfilled"
+          ? noteResult.value
+          : {
+              data: [],
+              error: {
+                message: "Failed to fetch Note articles",
+                status: 500,
+                platform: "note",
+              },
+            },
     };
   }
 
@@ -309,16 +349,27 @@ export class ArticleApiClient {
     return this.fetchFromApiRoute(undefined, 1, useRss);
   }
 
-  async fetchQiitaArticles(page = 1, perPage = 20): Promise<ApiResponse<Article>> {
-    return this.fetchFromApiRoute('qiita', page);
+  async fetchQiitaArticles(
+    page = 1,
+    perPage = 20,
+  ): Promise<ApiResponse<Article>> {
+    return this.fetchFromApiRoute("qiita", page);
   }
 
-  async fetchZennArticles(page = 1, perPage = 20, useRss = true): Promise<ApiResponse<Article>> {
-    return this.fetchFromApiRoute('zenn', page, useRss);
+  async fetchZennArticles(
+    page = 1,
+    perPage = 20,
+    useRss = true,
+  ): Promise<ApiResponse<Article>> {
+    return this.fetchFromApiRoute("zenn", page, useRss);
   }
 
-  async fetchNoteArticles(page = 1, perPage = 20, useRss = true): Promise<ApiResponse<Article>> {
-    return this.fetchFromApiRoute('note', page, useRss);
+  async fetchNoteArticles(
+    page = 1,
+    perPage = 20,
+    useRss = true,
+  ): Promise<ApiResponse<Article>> {
+    return this.fetchFromApiRoute("note", page, useRss);
   }
 }
 

--- a/app/lib/api-clients.ts
+++ b/app/lib/api-clients.ts
@@ -1,0 +1,326 @@
+import type { Article } from "@/types";
+import type { 
+  ZennArticle, 
+  QiitaArticle, 
+  NoteArticle, 
+  ApiResponse, 
+  ApiError 
+} from "@/types/api";
+
+// Constants
+const ZENN_API_BASE = "https://zenn.dev/api";
+const QIITA_API_BASE = "https://qiita.com/api/v2";
+const NOTE_API_BASE = "https://note.com/api/v2";
+
+// User IDs from the issue
+const USER_IDS = {
+  zenn: "yuji0207",
+  qiita: "yjn279", 
+  note: "yjn279"
+} as const;
+
+// Helper function to estimate reading time
+function estimateReadingTime(text: string): string {
+  const wordsPerMinute = 200;
+  const words = text.length / 5; // Rough estimate for Japanese text
+  const minutes = Math.ceil(words / wordsPerMinute);
+  return `${minutes}分`;
+}
+
+// Helper function to format numbers
+function formatCount(count: number): string {
+  if (count >= 1000) {
+    return `${(count / 1000).toFixed(1)}k`;
+  }
+  return count.toString();
+}
+
+// Helper function to format date
+function formatDate(dateString: string): string {
+  return new Date(dateString).toLocaleDateString('ja-JP', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit'
+  });
+}
+
+// Zenn API Client
+export class ZennApiClient {
+  private baseUrl = ZENN_API_BASE;
+  private username = USER_IDS.zenn;
+
+  async fetchArticles(page = 1, perPage = 20): Promise<ApiResponse<Article>> {
+    try {
+      // Zenn doesn't have a public API, so we'll use RSS or scraping approach
+      // For now, we'll return a simulated response indicating the limitation
+      const error: ApiError = {
+        message: "Zenn does not provide a public API. Consider using RSS feed or web scraping.",
+        status: 501,
+        platform: 'zenn'
+      };
+      
+      return {
+        data: [],
+        error,
+        hasMore: false
+      };
+    } catch (error) {
+      const apiError: ApiError = {
+        message: error instanceof Error ? error.message : "Unknown error occurred",
+        status: 500,
+        platform: 'zenn'
+      };
+      
+      return {
+        data: [],
+        error: apiError
+      };
+    }
+  }
+
+  // Alternative: RSS feed approach for Zenn
+  async fetchArticlesFromRSS(): Promise<ApiResponse<Article>> {
+    try {
+      const rssUrl = `https://zenn.dev/${this.username}/feed`;
+      
+      // Note: This would need to be implemented with a CORS proxy or server-side
+      const error: ApiError = {
+        message: "RSS parsing requires server-side implementation due to CORS restrictions",
+        status: 501,
+        platform: 'zenn'
+      };
+      
+      return {
+        data: [],
+        error
+      };
+    } catch (error) {
+      const apiError: ApiError = {
+        message: error instanceof Error ? error.message : "RSS fetch failed",
+        status: 500,
+        platform: 'zenn'
+      };
+      
+      return {
+        data: [],
+        error: apiError
+      };
+    }
+  }
+}
+
+// Qiita API Client
+export class QiitaApiClient {
+  private baseUrl = QIITA_API_BASE;
+  private username = USER_IDS.qiita;
+
+  async fetchArticles(page = 1, perPage = 20): Promise<ApiResponse<Article>> {
+    try {
+      const url = `${this.baseUrl}/users/${this.username}/items?page=${page}&per_page=${perPage}`;
+      
+      const response = await fetch(url, {
+        headers: {
+          'Accept': 'application/json',
+        },
+      });
+
+      if (!response.ok) {
+        const error: ApiError = {
+          message: `Qiita API error: ${response.status} ${response.statusText}`,
+          status: response.status,
+          platform: 'qiita'
+        };
+        
+        return {
+          data: [],
+          error
+        };
+      }
+
+      const qiitaArticles: QiitaArticle[] = await response.json();
+      
+      const articles: Article[] = qiitaArticles.map((article) => ({
+        id: `qiita-${article.id}`,
+        title: article.title,
+        description: article.body.substring(0, 200) + "...",
+        excerpt: article.body.substring(0, 100) + "...",
+        tags: article.tags.map(tag => tag.name),
+        url: article.url,
+        publishedAt: formatDate(article.created_at),
+        readTime: estimateReadingTime(article.body),
+        views: formatCount(article.page_views_count || 0),
+        likes: formatCount(article.likes_count),
+        platform: "Qiita",
+        featured: false
+      }));
+
+      return {
+        data: articles,
+        hasMore: qiitaArticles.length === perPage
+      };
+    } catch (error) {
+      const apiError: ApiError = {
+        message: error instanceof Error ? error.message : "Unknown error occurred",
+        status: 500,
+        platform: 'qiita'
+      };
+      
+      return {
+        data: [],
+        error: apiError
+      };
+    }
+  }
+}
+
+// Note API Client
+export class NoteApiClient {
+  private baseUrl = NOTE_API_BASE;
+  private username = USER_IDS.note;
+
+  async fetchArticles(page = 1, perPage = 20): Promise<ApiResponse<Article>> {
+    try {
+      // Note's API is also not publicly available in the same way
+      // We would need to use their RSS feed or implement server-side scraping
+      const error: ApiError = {
+        message: "Note does not provide a public API. Consider using RSS feed or web scraping.",
+        status: 501,
+        platform: 'note'
+      };
+      
+      return {
+        data: [],
+        error,
+        hasMore: false
+      };
+    } catch (error) {
+      const apiError: ApiError = {
+        message: error instanceof Error ? error.message : "Unknown error occurred",
+        status: 500,
+        platform: 'note'
+      };
+      
+      return {
+        data: [],
+        error: apiError
+      };
+    }
+  }
+
+  // Alternative: RSS feed approach for Note
+  async fetchArticlesFromRSS(): Promise<ApiResponse<Article>> {
+    try {
+      const rssUrl = `https://note.com/${this.username}/rss`;
+      
+      // Note: This would need to be implemented with a CORS proxy or server-side
+      const error: ApiError = {
+        message: "RSS parsing requires server-side implementation due to CORS restrictions",
+        status: 501,
+        platform: 'note'
+      };
+      
+      return {
+        data: [],
+        error
+      };
+    } catch (error) {
+      const apiError: ApiError = {
+        message: error instanceof Error ? error.message : "RSS fetch failed",
+        status: 500,
+        platform: 'note'
+      };
+      
+      return {
+        data: [],
+        error: apiError
+      };
+    }
+  }
+}
+
+// Combined API Client
+export class ArticleApiClient {
+  private zennClient = new ZennApiClient();
+  private qiitaClient = new QiitaApiClient();
+  private noteClient = new NoteApiClient();
+
+  // Check if we're running in browser
+  private get isBrowser(): boolean {
+    return typeof window !== 'undefined';
+  }
+
+  // Use API route when in browser, direct API when server-side
+  private async fetchFromApiRoute(platform?: string, page = 1, useRss = false): Promise<any> {
+    if (!this.isBrowser) {
+      // Server-side: use direct API calls
+      if (platform === 'qiita') {
+        return this.qiitaClient.fetchArticles(page);
+      } else if (platform === 'zenn') {
+        return this.zennClient.fetchArticles(page);
+      } else if (platform === 'note') {
+        return this.noteClient.fetchArticles(page);
+      } else {
+        return this.fetchAllArticlesDirect();
+      }
+    }
+
+    // Browser: use API route
+    const params = new URLSearchParams();
+    if (platform) params.set('platform', platform);
+    params.set('page', page.toString());
+    if (useRss) params.set('rss', 'true');
+
+    const response = await fetch(`/api/articles?${params}`);
+    return response.json();
+  }
+
+  private async fetchAllArticlesDirect(): Promise<{
+    zenn: ApiResponse<Article>;
+    qiita: ApiResponse<Article>;
+    note: ApiResponse<Article>;
+  }> {
+    const [zennResult, qiitaResult, noteResult] = await Promise.allSettled([
+      this.zennClient.fetchArticles(),
+      this.qiitaClient.fetchArticles(),
+      this.noteClient.fetchArticles()
+    ]);
+
+    return {
+      zenn: zennResult.status === 'fulfilled' ? zennResult.value : { 
+        data: [], 
+        error: { message: 'Failed to fetch Zenn articles', status: 500, platform: 'zenn' }
+      },
+      qiita: qiitaResult.status === 'fulfilled' ? qiitaResult.value : { 
+        data: [], 
+        error: { message: 'Failed to fetch Qiita articles', status: 500, platform: 'qiita' }
+      },
+      note: noteResult.status === 'fulfilled' ? noteResult.value : { 
+        data: [], 
+        error: { message: 'Failed to fetch Note articles', status: 500, platform: 'note' }
+      }
+    };
+  }
+
+  async fetchAllArticles(useRss = false): Promise<{
+    zenn: ApiResponse<Article>;
+    qiita: ApiResponse<Article>;
+    note: ApiResponse<Article>;
+  }> {
+    return this.fetchFromApiRoute(undefined, 1, useRss);
+  }
+
+  async fetchQiitaArticles(page = 1, perPage = 20): Promise<ApiResponse<Article>> {
+    return this.fetchFromApiRoute('qiita', page);
+  }
+
+  async fetchZennArticles(page = 1, perPage = 20, useRss = true): Promise<ApiResponse<Article>> {
+    return this.fetchFromApiRoute('zenn', page, useRss);
+  }
+
+  async fetchNoteArticles(page = 1, perPage = 20, useRss = true): Promise<ApiResponse<Article>> {
+    return this.fetchFromApiRoute('note', page, useRss);
+  }
+}
+
+// Export singleton instance
+export const articleApiClient = new ArticleApiClient();

--- a/app/lib/rss-parser.ts
+++ b/app/lib/rss-parser.ts
@@ -1,0 +1,158 @@
+// RSS Parser for Zenn and Note feeds
+// This is designed to work in Cloudflare Workers environment
+
+import type { Article } from "@/types";
+
+interface RSSItem {
+  title?: string;
+  link?: string;
+  description?: string;
+  pubDate?: string;
+  guid?: string;
+  content?: string;
+}
+
+interface ParsedRSS {
+  title?: string;
+  description?: string;
+  link?: string;
+  items: RSSItem[];
+}
+
+// Simple XML parser for RSS feeds
+export class RSSParser {
+  private extractTextContent(xml: string, tagName: string): string | null {
+    const regex = new RegExp(`<${tagName}[^>]*>(.*?)<\/${tagName}>`, 'is');
+    const match = xml.match(regex);
+    return match ? match[1].trim() : null;
+  }
+
+  private extractAllItems(xml: string): RSSItem[] {
+    const itemRegex = /<item[^>]*>(.*?)<\/item>/gis;
+    const items: RSSItem[] = [];
+    let match;
+
+    while ((match = itemRegex.exec(xml)) !== null) {
+      const itemXml = match[1];
+      
+      const item: RSSItem = {
+        title: this.extractTextContent(itemXml, 'title'),
+        link: this.extractTextContent(itemXml, 'link'),
+        description: this.extractTextContent(itemXml, 'description'),
+        pubDate: this.extractTextContent(itemXml, 'pubDate'),
+        guid: this.extractTextContent(itemXml, 'guid'),
+        content: this.extractTextContent(itemXml, 'content:encoded') || 
+                this.extractTextContent(itemXml, 'content')
+      };
+
+      items.push(item);
+    }
+
+    return items;
+  }
+
+  private parseRSS(xmlString: string): ParsedRSS {
+    const channelMatch = xmlString.match(/<channel[^>]*>(.*?)<\/channel>/is);
+    const channelXml = channelMatch ? channelMatch[1] : xmlString;
+
+    return {
+      title: this.extractTextContent(channelXml, 'title'),
+      description: this.extractTextContent(channelXml, 'description'),
+      link: this.extractTextContent(channelXml, 'link'),
+      items: this.extractAllItems(channelXml)
+    };
+  }
+
+  private formatDate(dateString: string): string {
+    try {
+      return new Date(dateString).toLocaleDateString('ja-JP', {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit'
+      });
+    } catch {
+      return dateString;
+    }
+  }
+
+  private estimateReadingTime(content: string): string {
+    const wordsPerMinute = 200;
+    const words = content.length / 5; // Rough estimate for Japanese text
+    const minutes = Math.ceil(words / wordsPerMinute);
+    return `${minutes}分`;
+  }
+
+  private extractDescription(content: string, maxLength = 200): string {
+    // Remove HTML tags
+    const textContent = content.replace(/<[^>]*>/g, '');
+    return textContent.length > maxLength 
+      ? textContent.substring(0, maxLength) + "..."
+      : textContent;
+  }
+
+  async fetchZennArticles(username: string): Promise<Article[]> {
+    try {
+      const rssUrl = `https://zenn.dev/${username}/feed`;
+      const response = await fetch(rssUrl);
+      
+      if (!response.ok) {
+        throw new Error(`Failed to fetch Zenn RSS: ${response.status}`);
+      }
+
+      const xmlText = await response.text();
+      const parsed = this.parseRSS(xmlText);
+
+      return parsed.items.map((item, index) => ({
+        id: `zenn-${item.guid || index}`,
+        title: item.title || "Untitled",
+        description: this.extractDescription(item.description || item.content || ""),
+        excerpt: this.extractDescription(item.content || item.description || "", 100),
+        tags: [], // RSS doesn't typically include tags, would need to parse from content
+        url: item.link || "",
+        publishedAt: this.formatDate(item.pubDate || ""),
+        readTime: this.estimateReadingTime(item.content || item.description || ""),
+        views: "N/A", // Not available in RSS
+        likes: "N/A", // Not available in RSS
+        platform: "Zenn",
+        featured: false
+      }));
+    } catch (error) {
+      console.error('Error fetching Zenn RSS:', error);
+      throw error;
+    }
+  }
+
+  async fetchNoteArticles(username: string): Promise<Article[]> {
+    try {
+      const rssUrl = `https://note.com/${username}/rss`;
+      const response = await fetch(rssUrl);
+      
+      if (!response.ok) {
+        throw new Error(`Failed to fetch Note RSS: ${response.status}`);
+      }
+
+      const xmlText = await response.text();
+      const parsed = this.parseRSS(xmlText);
+
+      return parsed.items.map((item, index) => ({
+        id: `note-${item.guid || index}`,
+        title: item.title || "Untitled",
+        description: this.extractDescription(item.description || item.content || ""),
+        excerpt: this.extractDescription(item.content || item.description || "", 100),
+        tags: [], // RSS doesn't typically include tags
+        url: item.link || "",
+        publishedAt: this.formatDate(item.pubDate || ""),
+        readTime: this.estimateReadingTime(item.content || item.description || ""),
+        views: "N/A", // Not available in RSS
+        likes: "N/A", // Not available in RSS
+        platform: "Note",
+        featured: false
+      }));
+    } catch (error) {
+      console.error('Error fetching Note RSS:', error);
+      throw error;
+    }
+  }
+}
+
+export const rssParser = new RSSParser();

--- a/app/lib/rss-parser.ts
+++ b/app/lib/rss-parser.ts
@@ -4,25 +4,25 @@
 import type { Article } from "@/types";
 
 interface RSSItem {
-  title?: string;
-  link?: string;
-  description?: string;
-  pubDate?: string;
-  guid?: string;
-  content?: string;
+  title?: string | null;
+  link?: string | null;
+  description?: string | null;
+  pubDate?: string | null;
+  guid?: string | null;
+  content?: string | null;
 }
 
 interface ParsedRSS {
-  title?: string;
-  description?: string;
-  link?: string;
+  title?: string | null;
+  description?: string | null;
+  link?: string | null;
   items: RSSItem[];
 }
 
 // Simple XML parser for RSS feeds
 export class RSSParser {
   private extractTextContent(xml: string, tagName: string): string | null {
-    const regex = new RegExp(`<${tagName}[^>]*>(.*?)<\/${tagName}>`, 'is');
+    const regex = new RegExp(`<${tagName}[^>]*>(.*?)<\/${tagName}>`, "is");
     const match = xml.match(regex);
     return match ? match[1].trim() : null;
   }
@@ -30,22 +30,24 @@ export class RSSParser {
   private extractAllItems(xml: string): RSSItem[] {
     const itemRegex = /<item[^>]*>(.*?)<\/item>/gis;
     const items: RSSItem[] = [];
-    let match;
+    let match: RegExpExecArray | null = itemRegex.exec(xml);
 
-    while ((match = itemRegex.exec(xml)) !== null) {
+    while (match !== null) {
       const itemXml = match[1];
-      
+
       const item: RSSItem = {
-        title: this.extractTextContent(itemXml, 'title'),
-        link: this.extractTextContent(itemXml, 'link'),
-        description: this.extractTextContent(itemXml, 'description'),
-        pubDate: this.extractTextContent(itemXml, 'pubDate'),
-        guid: this.extractTextContent(itemXml, 'guid'),
-        content: this.extractTextContent(itemXml, 'content:encoded') || 
-                this.extractTextContent(itemXml, 'content')
+        title: this.extractTextContent(itemXml, "title"),
+        link: this.extractTextContent(itemXml, "link"),
+        description: this.extractTextContent(itemXml, "description"),
+        pubDate: this.extractTextContent(itemXml, "pubDate"),
+        guid: this.extractTextContent(itemXml, "guid"),
+        content:
+          this.extractTextContent(itemXml, "content:encoded") ||
+          this.extractTextContent(itemXml, "content"),
       };
 
       items.push(item);
+      match = itemRegex.exec(xml);
     }
 
     return items;
@@ -56,19 +58,19 @@ export class RSSParser {
     const channelXml = channelMatch ? channelMatch[1] : xmlString;
 
     return {
-      title: this.extractTextContent(channelXml, 'title'),
-      description: this.extractTextContent(channelXml, 'description'),
-      link: this.extractTextContent(channelXml, 'link'),
-      items: this.extractAllItems(channelXml)
+      title: this.extractTextContent(channelXml, "title"),
+      description: this.extractTextContent(channelXml, "description"),
+      link: this.extractTextContent(channelXml, "link"),
+      items: this.extractAllItems(channelXml),
     };
   }
 
   private formatDate(dateString: string): string {
     try {
-      return new Date(dateString).toLocaleDateString('ja-JP', {
-        year: 'numeric',
-        month: '2-digit',
-        day: '2-digit'
+      return new Date(dateString).toLocaleDateString("ja-JP", {
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
       });
     } catch {
       return dateString;
@@ -84,9 +86,9 @@ export class RSSParser {
 
   private extractDescription(content: string, maxLength = 200): string {
     // Remove HTML tags
-    const textContent = content.replace(/<[^>]*>/g, '');
-    return textContent.length > maxLength 
-      ? textContent.substring(0, maxLength) + "..."
+    const textContent = content.replace(/<[^>]*>/g, "");
+    return textContent.length > maxLength
+      ? `${textContent.substring(0, maxLength)}...`
       : textContent;
   }
 
@@ -94,7 +96,7 @@ export class RSSParser {
     try {
       const rssUrl = `https://zenn.dev/${username}/feed`;
       const response = await fetch(rssUrl);
-      
+
       if (!response.ok) {
         throw new Error(`Failed to fetch Zenn RSS: ${response.status}`);
       }
@@ -105,19 +107,26 @@ export class RSSParser {
       return parsed.items.map((item, index) => ({
         id: `zenn-${item.guid || index}`,
         title: item.title || "Untitled",
-        description: this.extractDescription(item.description || item.content || ""),
-        excerpt: this.extractDescription(item.content || item.description || "", 100),
+        description: this.extractDescription(
+          item.description || item.content || "",
+        ),
+        excerpt: this.extractDescription(
+          item.content || item.description || "",
+          100,
+        ),
         tags: [], // RSS doesn't typically include tags, would need to parse from content
         url: item.link || "",
         publishedAt: this.formatDate(item.pubDate || ""),
-        readTime: this.estimateReadingTime(item.content || item.description || ""),
+        readTime: this.estimateReadingTime(
+          item.content || item.description || "",
+        ),
         views: "N/A", // Not available in RSS
         likes: "N/A", // Not available in RSS
         platform: "Zenn",
-        featured: false
+        featured: false,
       }));
     } catch (error) {
-      console.error('Error fetching Zenn RSS:', error);
+      console.error("Error fetching Zenn RSS:", error);
       throw error;
     }
   }
@@ -126,7 +135,7 @@ export class RSSParser {
     try {
       const rssUrl = `https://note.com/${username}/rss`;
       const response = await fetch(rssUrl);
-      
+
       if (!response.ok) {
         throw new Error(`Failed to fetch Note RSS: ${response.status}`);
       }
@@ -137,19 +146,26 @@ export class RSSParser {
       return parsed.items.map((item, index) => ({
         id: `note-${item.guid || index}`,
         title: item.title || "Untitled",
-        description: this.extractDescription(item.description || item.content || ""),
-        excerpt: this.extractDescription(item.content || item.description || "", 100),
+        description: this.extractDescription(
+          item.description || item.content || "",
+        ),
+        excerpt: this.extractDescription(
+          item.content || item.description || "",
+          100,
+        ),
         tags: [], // RSS doesn't typically include tags
         url: item.link || "",
         publishedAt: this.formatDate(item.pubDate || ""),
-        readTime: this.estimateReadingTime(item.content || item.description || ""),
+        readTime: this.estimateReadingTime(
+          item.content || item.description || "",
+        ),
         views: "N/A", // Not available in RSS
         likes: "N/A", // Not available in RSS
         platform: "Note",
-        featured: false
+        featured: false,
       }));
     } catch (error) {
-      console.error('Error fetching Note RSS:', error);
+      console.error("Error fetching Note RSS:", error);
       throw error;
     }
   }

--- a/app/routes/api.articles.tsx
+++ b/app/routes/api.articles.tsx
@@ -1,19 +1,24 @@
-import { json } from "react-router";
-import type { Route } from "./+types/api.articles";
 import { articleApiClient } from "@/lib/api-clients";
 import { rssParser } from "@/lib/rss-parser";
+import { json } from "@remix-run/cloudflare";
+import type { LoaderFunctionArgs } from "@remix-run/cloudflare";
+import type { Route } from "./+types/api.articles";
 
 // User IDs from the issue
 const USER_IDS = {
   zenn: "yuji0207",
-  qiita: "yjn279", 
-  note: "yjn279"
+  qiita: "yjn279",
+  note: "yjn279",
 } as const;
 
-export async function loader({ request }: Route.LoaderArgs) {
+export async function loader({ request }: LoaderFunctionArgs) {
   const url = new URL(request.url);
-  const platform = url.searchParams.get("platform") as 'zenn' | 'qiita' | 'note' | null;
-  const page = parseInt(url.searchParams.get("page") || "1");
+  const platform = url.searchParams.get("platform") as
+    | "zenn"
+    | "qiita"
+    | "note"
+    | null;
+  const page = Number.parseInt(url.searchParams.get("page") || "1");
   const useRss = url.searchParams.get("rss") === "true";
 
   try {
@@ -21,85 +26,101 @@ export async function loader({ request }: Route.LoaderArgs) {
       // Use Qiita API
       const result = await articleApiClient.fetchQiitaArticles(page);
       return json(result);
-    } else if (platform === "zenn" && useRss) {
+    }
+
+    if (platform === "zenn" && useRss) {
       // Use RSS for Zenn
       try {
         const articles = await rssParser.fetchZennArticles(USER_IDS.zenn);
         return json({
           data: articles,
-          hasMore: false
+          hasMore: false,
         });
       } catch (error) {
         return json({
           data: [],
           error: {
-            message: error instanceof Error ? error.message : "Failed to fetch Zenn RSS",
+            message:
+              error instanceof Error
+                ? error.message
+                : "Failed to fetch Zenn RSS",
             status: 500,
-            platform: 'zenn'
-          }
+            platform: "zenn",
+          },
         });
       }
-    } else if (platform === "note" && useRss) {
+    }
+
+    if (platform === "note" && useRss) {
       // Use RSS for Note
       try {
         const articles = await rssParser.fetchNoteArticles(USER_IDS.note);
         return json({
           data: articles,
-          hasMore: false
+          hasMore: false,
         });
       } catch (error) {
         return json({
           data: [],
           error: {
-            message: error instanceof Error ? error.message : "Failed to fetch Note RSS",
+            message:
+              error instanceof Error
+                ? error.message
+                : "Failed to fetch Note RSS",
             status: 500,
-            platform: 'note'
-          }
+            platform: "note",
+          },
         });
       }
-    } else if (!platform) {
+    }
+
+    if (!platform) {
       // Fetch all platforms
       const results = await articleApiClient.fetchAllArticles();
-      
+
       // Try to get RSS data for Zenn and Note if requested
       if (useRss) {
         try {
           const [zennArticles, noteArticles] = await Promise.allSettled([
             rssParser.fetchZennArticles(USER_IDS.zenn),
-            rssParser.fetchNoteArticles(USER_IDS.note)
+            rssParser.fetchNoteArticles(USER_IDS.note),
           ]);
 
-          if (zennArticles.status === 'fulfilled') {
+          if (zennArticles.status === "fulfilled") {
             results.zenn = { data: zennArticles.value, hasMore: false };
           }
-          if (noteArticles.status === 'fulfilled') {
+          if (noteArticles.status === "fulfilled") {
             results.note = { data: noteArticles.value, hasMore: false };
           }
         } catch (error) {
-          console.error('Error fetching RSS feeds:', error);
+          console.error("Error fetching RSS feeds:", error);
         }
       }
 
       return json(results);
-    } else {
-      // Platform not supported without RSS
-      return json({
-        data: [],
-        error: {
-          message: `Platform ${platform} not supported without RSS`,
-          status: 501,
-          platform
-        }
-      });
     }
-  } catch (error) {
+
+    // Platform not supported without RSS
     return json({
       data: [],
       error: {
-        message: error instanceof Error ? error.message : "Internal server error",
-        status: 500,
-        platform: platform || 'unknown'
-      }
-    }, { status: 500 });
+        message: `Platform ${platform} not supported without RSS`,
+        status: 501,
+        platform,
+      },
+    });
+  } catch (error) {
+    return json(
+      {
+        data: [],
+        error: {
+          message:
+            error instanceof Error ? error.message : "Internal server error",
+          status: 500,
+          platform: platform || "unknown",
+        },
+      },
+      { status: 500 },
+    );
   }
 }

--- a/app/routes/api.articles.tsx
+++ b/app/routes/api.articles.tsx
@@ -1,0 +1,105 @@
+import { json } from "react-router";
+import type { Route } from "./+types/api.articles";
+import { articleApiClient } from "@/lib/api-clients";
+import { rssParser } from "@/lib/rss-parser";
+
+// User IDs from the issue
+const USER_IDS = {
+  zenn: "yuji0207",
+  qiita: "yjn279", 
+  note: "yjn279"
+} as const;
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const url = new URL(request.url);
+  const platform = url.searchParams.get("platform") as 'zenn' | 'qiita' | 'note' | null;
+  const page = parseInt(url.searchParams.get("page") || "1");
+  const useRss = url.searchParams.get("rss") === "true";
+
+  try {
+    if (platform === "qiita") {
+      // Use Qiita API
+      const result = await articleApiClient.fetchQiitaArticles(page);
+      return json(result);
+    } else if (platform === "zenn" && useRss) {
+      // Use RSS for Zenn
+      try {
+        const articles = await rssParser.fetchZennArticles(USER_IDS.zenn);
+        return json({
+          data: articles,
+          hasMore: false
+        });
+      } catch (error) {
+        return json({
+          data: [],
+          error: {
+            message: error instanceof Error ? error.message : "Failed to fetch Zenn RSS",
+            status: 500,
+            platform: 'zenn'
+          }
+        });
+      }
+    } else if (platform === "note" && useRss) {
+      // Use RSS for Note
+      try {
+        const articles = await rssParser.fetchNoteArticles(USER_IDS.note);
+        return json({
+          data: articles,
+          hasMore: false
+        });
+      } catch (error) {
+        return json({
+          data: [],
+          error: {
+            message: error instanceof Error ? error.message : "Failed to fetch Note RSS",
+            status: 500,
+            platform: 'note'
+          }
+        });
+      }
+    } else if (!platform) {
+      // Fetch all platforms
+      const results = await articleApiClient.fetchAllArticles();
+      
+      // Try to get RSS data for Zenn and Note if requested
+      if (useRss) {
+        try {
+          const [zennArticles, noteArticles] = await Promise.allSettled([
+            rssParser.fetchZennArticles(USER_IDS.zenn),
+            rssParser.fetchNoteArticles(USER_IDS.note)
+          ]);
+
+          if (zennArticles.status === 'fulfilled') {
+            results.zenn = { data: zennArticles.value, hasMore: false };
+          }
+          if (noteArticles.status === 'fulfilled') {
+            results.note = { data: noteArticles.value, hasMore: false };
+          }
+        } catch (error) {
+          console.error('Error fetching RSS feeds:', error);
+        }
+      }
+
+      return json(results);
+    } else {
+      // Platform not supported without RSS
+      return json({
+        data: [],
+        error: {
+          message: `Platform ${platform} not supported without RSS`,
+          status: 501,
+          platform
+        }
+      });
+    }
+  } catch (error) {
+    return json({
+      data: [],
+      error: {
+        message: error instanceof Error ? error.message : "Internal server error",
+        status: 500,
+        platform: platform || 'unknown'
+      }
+    }, { status: 500 });
+  }
+}

--- a/app/routes/articles.tsx
+++ b/app/routes/articles.tsx
@@ -250,36 +250,48 @@ export default function Articles() {
               現在はQiitaのAPIのみ利用可能です。
             </p>
           </div>
-          
+
           {/* Qiita Articles */}
           <div className="mb-12">
             <h3 className="text-2xl font-semibold text-gray-900 mb-6 flex items-center gap-2">
               <Badge className="bg-green-100 text-green-800">Qiita</Badge>
               記事一覧
             </h3>
-            <ArticlesList platform="qiita" showLoadMore={true} showRefresh={true} />
+            <ArticlesList
+              platform="qiita"
+              showLoadMore={true}
+              showRefresh={true}
+            />
           </div>
 
           <Separator className="my-8" />
-          
+
           {/* Zenn Articles */}
           <div className="mb-12">
             <h3 className="text-2xl font-semibold text-gray-900 mb-6 flex items-center gap-2">
               <Badge className="bg-blue-100 text-blue-800">Zenn</Badge>
               記事一覧（RSSフィード）
             </h3>
-            <ArticlesList platform="zenn" showLoadMore={false} showRefresh={true} />
+            <ArticlesList
+              platform="zenn"
+              showLoadMore={false}
+              showRefresh={true}
+            />
           </div>
 
           <Separator className="my-8" />
-          
+
           {/* Note Articles */}
           <div className="mb-12">
             <h3 className="text-2xl font-semibold text-gray-900 mb-6 flex items-center gap-2">
               <Badge className="bg-purple-100 text-purple-800">Note</Badge>
               記事一覧（RSSフィード）
             </h3>
-            <ArticlesList platform="note" showLoadMore={false} showRefresh={true} />
+            <ArticlesList
+              platform="note"
+              showLoadMore={false}
+              showRefresh={true}
+            />
           </div>
         </div>
       </section>
@@ -296,14 +308,14 @@ export default function Articles() {
               ZennやQiitaでフォローして、新しい記事の通知を受け取りましょう。
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Button 
-                size="lg" 
+              <Button
+                size="lg"
                 className="bg-blue-600 hover:bg-blue-700"
                 asChild
               >
-                <a 
-                  href="https://zenn.dev/yuji0207" 
-                  target="_blank" 
+                <a
+                  href="https://zenn.dev/yuji0207"
+                  target="_blank"
                   rel="noopener noreferrer"
                 >
                   <ExternalLink className="h-4 w-4 mr-2" />
@@ -311,9 +323,9 @@ export default function Articles() {
                 </a>
               </Button>
               <Button variant="outline" size="lg" asChild>
-                <a 
-                  href="https://qiita.com/yjn279" 
-                  target="_blank" 
+                <a
+                  href="https://qiita.com/yjn279"
+                  target="_blank"
                   rel="noopener noreferrer"
                 >
                   <ExternalLink className="h-4 w-4 mr-2" />

--- a/app/routes/articles.tsx
+++ b/app/routes/articles.tsx
@@ -1,5 +1,6 @@
 import { Footer } from "@/components/layout/Footer";
 import { Header } from "@/components/layout/Header";
+import { ArticlesList } from "@/components/sections/ArticlesList";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -9,6 +10,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
 import { getFeaturedArticles, getOtherArticles } from "@/data/articles";
 import type { Article } from "@/types";
 import {
@@ -236,6 +238,52 @@ export default function Articles() {
         </div>
       </section>
 
+      {/* Live Articles from APIs */}
+      <section className="py-16 px-4 bg-gray-50">
+        <div className="container mx-auto">
+          <div className="text-center mb-12">
+            <h2 className="text-3xl font-bold text-gray-900 mb-4">
+              最新記事（API取得）
+            </h2>
+            <p className="text-gray-600 max-w-2xl mx-auto">
+              Zenn、Qiita、Noteから最新の記事を自動取得して表示しています。
+              現在はQiitaのAPIのみ利用可能です。
+            </p>
+          </div>
+          
+          {/* Qiita Articles */}
+          <div className="mb-12">
+            <h3 className="text-2xl font-semibold text-gray-900 mb-6 flex items-center gap-2">
+              <Badge className="bg-green-100 text-green-800">Qiita</Badge>
+              記事一覧
+            </h3>
+            <ArticlesList platform="qiita" showLoadMore={true} showRefresh={true} />
+          </div>
+
+          <Separator className="my-8" />
+          
+          {/* Zenn Articles */}
+          <div className="mb-12">
+            <h3 className="text-2xl font-semibold text-gray-900 mb-6 flex items-center gap-2">
+              <Badge className="bg-blue-100 text-blue-800">Zenn</Badge>
+              記事一覧（RSSフィード）
+            </h3>
+            <ArticlesList platform="zenn" showLoadMore={false} showRefresh={true} />
+          </div>
+
+          <Separator className="my-8" />
+          
+          {/* Note Articles */}
+          <div className="mb-12">
+            <h3 className="text-2xl font-semibold text-gray-900 mb-6 flex items-center gap-2">
+              <Badge className="bg-purple-100 text-purple-800">Note</Badge>
+              記事一覧（RSSフィード）
+            </h3>
+            <ArticlesList platform="note" showLoadMore={false} showRefresh={true} />
+          </div>
+        </div>
+      </section>
+
       {/* CTA Section */}
       <section className="py-16 px-4">
         <div className="container mx-auto text-center">
@@ -248,13 +296,29 @@ export default function Articles() {
               ZennやQiitaでフォローして、新しい記事の通知を受け取りましょう。
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Button size="lg" className="bg-blue-600 hover:bg-blue-700">
-                <ExternalLink className="h-4 w-4 mr-2" />
-                Follow on Zenn
+              <Button 
+                size="lg" 
+                className="bg-blue-600 hover:bg-blue-700"
+                asChild
+              >
+                <a 
+                  href="https://zenn.dev/yuji0207" 
+                  target="_blank" 
+                  rel="noopener noreferrer"
+                >
+                  <ExternalLink className="h-4 w-4 mr-2" />
+                  Follow on Zenn
+                </a>
               </Button>
-              <Button variant="outline" size="lg">
-                <ExternalLink className="h-4 w-4 mr-2" />
-                Follow on Qiita
+              <Button variant="outline" size="lg" asChild>
+                <a 
+                  href="https://qiita.com/yjn279" 
+                  target="_blank" 
+                  rel="noopener noreferrer"
+                >
+                  <ExternalLink className="h-4 w-4 mr-2" />
+                  Follow on Qiita
+                </a>
               </Button>
             </div>
           </div>

--- a/app/types/api.ts
+++ b/app/types/api.ts
@@ -37,7 +37,14 @@ export interface QiitaArticle {
   coediting: boolean;
   comments_count: number;
   created_at: string;
-  group: any | null;
+  group: {
+    created_at: string;
+    description: string;
+    name: string;
+    private: boolean;
+    updated_at: string;
+    url_name: string;
+  } | null;
   id: string;
   likes_count: number;
   private: boolean;
@@ -95,7 +102,7 @@ export interface NoteArticle {
 export interface ApiError {
   message: string;
   status: number;
-  platform: 'zenn' | 'qiita' | 'note';
+  platform: "zenn" | "qiita" | "note";
 }
 
 // Unified response type

--- a/app/types/api.ts
+++ b/app/types/api.ts
@@ -1,0 +1,107 @@
+// API response types for different platforms
+
+export interface ZennArticle {
+  id: number;
+  title: string;
+  slug: string;
+  created_at: string;
+  updated_at: string;
+  published_at: string;
+  path: string;
+  user: {
+    id: number;
+    username: string;
+    name: string;
+    avatar_small_url: string;
+  };
+  article_type: string;
+  emoji: string;
+  is_suspending_private: boolean;
+  published: boolean;
+  slug_: string;
+  comments_count: number;
+  liked_count: number;
+  body_letters_count: number;
+  reading_time: number;
+  publication: {
+    id: number;
+    name: string;
+    display_name: string;
+    avatar_small_url: string;
+  } | null;
+}
+
+export interface QiitaArticle {
+  rendered_body: string;
+  body: string;
+  coediting: boolean;
+  comments_count: number;
+  created_at: string;
+  group: any | null;
+  id: string;
+  likes_count: number;
+  private: boolean;
+  reactions_count: number;
+  stocks_count: number;
+  tags: Array<{
+    name: string;
+    versions: string[];
+  }>;
+  title: string;
+  updated_at: string;
+  url: string;
+  user: {
+    description: string;
+    facebook_id: string;
+    followees_count: number;
+    followers_count: number;
+    github_login_name: string;
+    id: string;
+    items_count: number;
+    linkedin_id: string;
+    location: string;
+    name: string;
+    organization: string;
+    permanent_id: number;
+    profile_image_url: string;
+    team_only: boolean;
+    twitter_screen_name: string;
+    website_url: string;
+  };
+  page_views_count: number;
+}
+
+export interface NoteArticle {
+  id: string;
+  name: string;
+  description: string;
+  eyecatch: string;
+  publish_at: string;
+  like_count: number;
+  comment_count: number;
+  is_liked: boolean;
+  hashtags: Array<{
+    name: string;
+  }>;
+  user: {
+    id: string;
+    name: string;
+    nickname: string;
+    profile_image_url: string;
+  };
+}
+
+// API Error types
+export interface ApiError {
+  message: string;
+  status: number;
+  platform: 'zenn' | 'qiita' | 'note';
+}
+
+// Unified response type
+export interface ApiResponse<T> {
+  data: T[];
+  error?: ApiError;
+  hasMore?: boolean;
+  nextPage?: string | number;
+}


### PR DESCRIPTION
Fixes #13

## 概要
Zenn、Qiita、Noteの3サイトについて、指定されたIDの記事一覧をAPIから取得する機能を実装しました。

## 主な変更
- Qiita公式APIを使用した記事取得
- ZennとNoteはRSSフィード解析対応
- 統一された記事データ型とエラーハンドリング
- レスポンシブデザイン対応

## 技術詳細
- TypeScript型安全性の確保
- React Router v7との統合
- Cloudflare Workers環境での動作確認

Generated with [Claude Code](https://claude.ai/code)